### PR TITLE
Set max number of posts per page to 9

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "url": "https://eduardogomez.io"
   },
   "config": {
-    "posts_per_page": 10,
+    "posts_per_page": 9,
     "image_sizes": {
       "xxs": {
         "width": 30


### PR DESCRIPTION
Jag lyckas tyvärr inte lösa så det bara är 9 när ingen featured artikel finns, eftersom det verkar kontrolleras helt från variablen i package.json. Just nu finns ingen featured artikel, så vi kan kanske ändra tillbaka om sådana tillkommer.